### PR TITLE
type-hint validation error parameters to be optional...

### DIFF
--- a/lib/Api/Data/ValidationErrorInterface.php
+++ b/lib/Api/Data/ValidationErrorInterface.php
@@ -15,7 +15,7 @@ interface ValidationErrorInterface
      * @param string $keyword
      * @return ValidationErrorInterface
      */
-    public function setKeyword(string $keyword): ValidationErrorInterface;
+    public function setKeyword(?string $keyword): ValidationErrorInterface;
 
     /**
      * @return string|null
@@ -26,7 +26,7 @@ interface ValidationErrorInterface
      * @param string $dataPath
      * @return ValidationErrorInterface
      */
-    public function setDataPath(string $dataPath): ValidationErrorInterface;
+    public function setDataPath(?string $dataPath): ValidationErrorInterface;
 
     /**
      * @return string|null
@@ -37,7 +37,7 @@ interface ValidationErrorInterface
      * @param string $schemaPath
      * @return ValidationErrorInterface
      */
-    public function setSchemaPath(string $schemaPath): ValidationErrorInterface;
+    public function setSchemaPath(?string $schemaPath): ValidationErrorInterface;
 
     /**
      * @return array|null
@@ -48,7 +48,7 @@ interface ValidationErrorInterface
      * @param array $params
      * @return ValidationErrorInterface
      */
-    public function setParams(array $params): ValidationErrorInterface;
+    public function setParams(?array $params): ValidationErrorInterface;
 
     /**
      * @return string|null
@@ -59,5 +59,5 @@ interface ValidationErrorInterface
      * @param string $message
      * @return ValidationErrorInterface
      */
-    public function setMessage(string $message): ValidationErrorInterface;
+    public function setMessage(?string $message): ValidationErrorInterface;
 }

--- a/lib/Model/Data/ValidationError.php
+++ b/lib/Model/Data/ValidationError.php
@@ -35,7 +35,7 @@ class ValidationError implements ValidationErrorInterface
      * @param string $keyword
      * @return ValidationErrorInterface
      */
-    public function setKeyword(string $keyword): ValidationErrorInterface
+    public function setKeyword(?string $keyword): ValidationErrorInterface
     {
         $this->parameters[self::KEYWORD] = $keyword;
 
@@ -54,7 +54,7 @@ class ValidationError implements ValidationErrorInterface
      * @param string $dataPath
      * @return ValidationErrorInterface
      */
-    public function setDataPath(string $dataPath): ValidationErrorInterface
+    public function setDataPath(?string $dataPath): ValidationErrorInterface
     {
         $this->parameters[self::DATA_PATH] = $dataPath;
 
@@ -73,7 +73,7 @@ class ValidationError implements ValidationErrorInterface
      * @param string $schemaPath
      * @return ValidationErrorInterface
      */
-    public function setSchemaPath(string $schemaPath): ValidationErrorInterface
+    public function setSchemaPath(?string $schemaPath): ValidationErrorInterface
     {
         $this->parameters[self::SCHEMA_PATH] = $schemaPath;
 
@@ -92,7 +92,7 @@ class ValidationError implements ValidationErrorInterface
      * @param array $params
      * @return ValidationErrorInterface
      */
-    public function setParams(array $params): ValidationErrorInterface
+    public function setParams(?array $params): ValidationErrorInterface
     {
         $this->parameters[self::PARAMS] = $params;
 
@@ -111,7 +111,7 @@ class ValidationError implements ValidationErrorInterface
      * @param string $message
      * @return ValidationErrorInterface
      */
-    public function setMessage(string $message): ValidationErrorInterface
+    public function setMessage(?string $message): ValidationErrorInterface
     {
         $this->parameters[self::MESSAGE] = $message;
 


### PR DESCRIPTION
so that API responses from TreviPay that do not include all fields do not cause PHP to throw a TypeError
when the setters are called from ApiClient.php line 154-159

This currently happens when processing error responses from TreviPay, which means that the expected exception is not thrown.

Example error response from Trevipay (see validationErrors at end - there are only two params here, so the above-mentioned TypeError problem occurs when ApiClient.php calls setters but passes no value)

```
array (
  'type' => 'call to the MSTS API (Create a authorization)',
  'request_url' => 'https://trevipay.app/api/v2/authorizations',
  'request_http_method' => 'POST',
  'request_auth_header' => 'Authorization: Bearer b1e9e3a6********',
  'request' =>
  array (
    'seller_id' => '7f6c95f5********',
    'buyer_id' => '42343725********',
    'currency' => 'AUD',
    'authorized_amount' => 0,
  ),
  'http_error' =>
  array (
    'error' => 'Client error: `POST https://trevipay.app/api/v2/authorizations` resulted in a `400 Bad Request` response:
{"code":"validation.body_not_matching_json_schema","message":"Request body failed JSON schema validation.","validationEr (truncated...)
',
    'code' => 400,
  ),
  'response_expected_http_code' => 201,
  'response_http_code' => 400,
  'response' =>
  array (
    'code' => 'validation.body_not_matching_json_schema',
    'message' => 'Request body failed JSON schema validation.',
    'validationErrors' =>
    array (
      0 =>
      array (
        'dataPath' => '.authorized_amount',
        'message' => 'should be >= 1',
      ),
    ),
  ),
)
```